### PR TITLE
[feat] #8 책 검색화면에 직접추가 버튼 구현

### DIFF
--- a/UnknownBookArchive/UnknownBookArchive/BookSearch/View/BookSearchCell.swift
+++ b/UnknownBookArchive/UnknownBookArchive/BookSearch/View/BookSearchCell.swift
@@ -59,18 +59,21 @@ class BookSearchCell: UITableViewCell {
         }
         titleLabel.snp.makeConstraints {
             $0.leading.equalTo(thumnailImage.snp.trailing).offset(10)
+            $0.trailing.equalToSuperview().inset(20)
             $0.top.equalToSuperview().inset(15)
         }
         authorLabel.snp.makeConstraints {
             $0.leading.equalTo(thumnailImage.snp.trailing).offset(10)
+            $0.trailing.equalToSuperview().inset(30)
             $0.top.equalTo(titleLabel.snp.bottom).offset(5)
         }
         publisherLabel.snp.makeConstraints {
             $0.leading.equalTo(thumnailImage.snp.trailing).offset(10)
+            $0.trailing.equalToSuperview().inset(30)
             $0.top.equalTo(authorLabel.snp.bottom).offset(5)
-
         }
     }
+    
     func setData(item: BookItem) {
         self.titleLabel.text = item.title
         self.authorLabel.text = item.author

--- a/UnknownBookArchive/UnknownBookArchive/BookSearch/ViewModel/BookSearchViewModel.swift
+++ b/UnknownBookArchive/UnknownBookArchive/BookSearch/ViewModel/BookSearchViewModel.swift
@@ -9,25 +9,29 @@ class BookSearchViewModel {
     
     private let apiService = BookRepository()
     
-    let bookList = BehaviorSubject<[Book]>(value: [])
+    let bookList = BehaviorRelay<[Book]>(value: [])
+    let viewState = BehaviorRelay<SearchState>(value: .initial)
     
     func search(query: String) {
         
         guard !query.isEmpty else {
-            // 추후에 검색 전 안내멘트 + 책 추가 버튼 추가필요
-            bookList.onNext([])
+            viewState.accept(.initial)
             return
         }
         apiService.searchBooks(query: query)
             .subscribe(onSuccess: { [weak self] items in
-                self?.bookList.onNext(items)
+                self?.bookList.accept(items)
+                self?.viewState.accept(.success)
             }, onFailure: { [weak self] error in
-                // 검색 실페시 안내멘트 + 책 추가 버튼 추가필요
                 print("검색 실패: \(error)")
-                self?.bookList.onNext([])
+                self?.viewState.accept(.error(error))
             })
             .disposed(by: disposeBag)
-
+    }
+    // 초기 상태로 돌리기 (검색 취소시 사용)
+    func resetSearchState() {
+        self.viewState.accept(.initial)
+        self.bookList.accept([])
     }
 }
 

--- a/UnknownBookArchive/UnknownBookArchive/BookSearch/ViewModel/SearchState.swift
+++ b/UnknownBookArchive/UnknownBookArchive/BookSearch/ViewModel/SearchState.swift
@@ -1,0 +1,7 @@
+// 검색 페이지 상태 확인
+enum SearchState {
+    case initial
+    case loading
+    case success
+    case error(Error)
+}

--- a/UnknownBookArchive/UnknownBookArchive/Model/BookRepository.swift
+++ b/UnknownBookArchive/UnknownBookArchive/Model/BookRepository.swift
@@ -15,7 +15,6 @@ class BookRepository {
         self.apiKey = Bundle.main.infoDictionary?["APIKey"] as? String ?? ""
         
         if self.apiKey.isEmpty {
-            print("API키를 찾을 수 없습니다.")
         }
     }
     func searchBooks(query: String) -> Single<[BookItem]> {
@@ -24,8 +23,6 @@ class BookRepository {
         else {
             return Single.error(APIError.invalidURL)
         }
-        // 디버깅용
-        print("API URL: \(url)")
         return networkManager.fetch(url: url)
             .map { (response: BookResponse) in
                 return response.item


### PR DESCRIPTION
## ☄️Pull Request
이슈번호 #8 
## 💬 작업 내용 + 변경 사항
- 서치바 비어있을 때, 검색 실패 했을 때 구분해서 안내멘트 추가와 직접 추가 버튼 추가
-  검색 후 취소 버튼 누르면 처음으로 돌아감
## 📷 구현 
![feature#8](https://github.com/user-attachments/assets/461bf793-1c3a-4636-9e84-68f9c42e06ae)


## Close Issue
Close #12 
# :두꺼운_확인_표시:Checklist
- [ ✅ ] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [ ✅ ] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [ ✅] 필요없는 주석, 프린트문 제거했는지 확인
- [ ✅ ] 컨벤션 지켰는지 확인
- [ ✅ ] final, private 제대로 넣었는지 확인
- [ ✅ ] 다양한 디바이스에 레이아웃이 대응되는지 확인
