### PR TITLE
[feat] #42 책 상세 기록 후 페이지 구현

### DIFF
--- a/UnknownBookArchive/UnknownBookArchive/BookDetail/View/BookDetailViewController.swift
+++ b/UnknownBookArchive/UnknownBookArchive/BookDetail/View/BookDetailViewController.swift
@@ -2,10 +2,37 @@
 import UIKit
 import SnapKit
 import CoreData
+import RxSwift
+import RxCocoa
 
 class BookDetailViewController: UIViewController {
     
+    let disposeBag = DisposeBag()
     var book: Book?
+    
+    private let topView = TopView()
+    private let contentView = UIView()
+    
+    private let coverImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = UIColor(red: 0.933, green: 0.933, blue: 0.933, alpha: 1)
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = 8
+        imageView.isUserInteractionEnabled = true
+        return imageView
+    }()
+    // 상태, 책 포맷 스택뷰
+    private let stateFormatStackView: UIStackView = {
+        let stView = UIStackView()
+        stView.axis = .horizontal
+        stView.spacing = 12
+        stView.alignment = .leading
+        return stView
+    }()
+    private let formatSpacer = UIView()
+    private let stateButton = BaseButton()
+    private let formatButton = BaseButton()
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.textColor = .black
@@ -18,38 +45,353 @@ class BookDetailViewController: UIViewController {
         label.font = .systemFont(ofSize: 15, weight: .regular)
         return label
     }()
-
+    private let publisherLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .black
+        label.font = .systemFont(ofSize: 15, weight: .regular)
+        return label
+    }()
+    // 시작, 종료 스택뷰
+    private let dateStackView: UIStackView = {
+        let stView = UIStackView()
+        stView.axis = .horizontal
+        stView.distribution = .fill
+        stView.alignment = .fill
+        return stView
+    }()
+    private let dateSpacer = UIView()
+    // 시작일, 종료일
+    private let startDateLabel: UILabel = {
+        let label = UILabel()
+        label.layer.cornerRadius = 8
+        label.layer.borderWidth = 1
+        label.textColor = UIColor(red: 0.481, green: 0.679, blue: 0.572, alpha: 1)
+        label.layer.borderColor = UIColor(red: 0.852, green: 0.908, blue: 0.878, alpha: 1).cgColor
+        label.textAlignment = .center
+        label.font = UIFont.systemFont(ofSize: 14, weight: .semibold)
+        return label
+    }()
+    private let endDateLabel: UILabel = {
+        let label = UILabel()
+        label.layer.cornerRadius = 8
+        label.layer.borderWidth = 1
+        label.layer.borderColor = UIColor(red: 0.855, green: 0.883, blue: 0.965, alpha: 1).cgColor
+        label.textColor = UIColor(red: 0.372, green: 0.495, blue: 0.848, alpha: 1)
+        label.textAlignment = .center
+        label.font = UIFont.systemFont(ofSize: 14, weight: .semibold)
+        return label
+    }()
+    
+    private let tagsStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 7.5
+        stackView.alignment = .leading
+        return stackView
+    }()
+    
+    // 하단 좋아요, 저널 보기 버튼
+    private let bottomButtonStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        return stackView
+    }()
+    private let likeButton: UIButton = {
+        let button = UIButton()
+        button.layer.cornerRadius = 8
+        button.backgroundColor = UIColor(red: 0.968, green: 0.974, blue: 0.992, alpha: 1)
+        let normalImage = UIImage(systemName: "heart")
+        button.setImage(normalImage, for: .normal)
+        let selectedImage = UIImage(systemName: "heart.fill")
+        button.setImage(selectedImage, for: .selected)
+        button.tintColor = .primaryColor
+        return button
+    }()
+    private let journalButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .primaryColor
+        button.setTitle("저널 보기", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+        button.layer.cornerRadius = 8
+        return button
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
         setConstraints()
         displayBookInfo()
+        bind()
 
     }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+    
     private func configureUI() {
         view.backgroundColor = .white
-        [
-            titleLabel, authorLabel
-        ].forEach { view.addSubview($0) }
+        contentView.backgroundColor = .basicBackground
+
+        [topView, contentView].forEach { view.addSubview($0) }
+        [coverImageView, stateFormatStackView, titleLabel, authorLabel, publisherLabel, dateStackView, tagsStackView, bottomButtonStackView].forEach { contentView.addSubview($0) }
+        [stateButton, formatButton, formatSpacer].forEach { stateFormatStackView.addArrangedSubview($0) }
+        [startDateLabel, dateSpacer, endDateLabel].forEach { dateStackView.addArrangedSubview($0) }
+        [likeButton, journalButton].forEach { bottomButtonStackView.addArrangedSubview($0) }
     }
     private func setConstraints() {
-        titleLabel.snp.makeConstraints {
+        topView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(60)
+            $0.leading.trailing.equalToSuperview()
+        }
+        contentView.snp.makeConstraints {
+            $0.top.equalTo(topView.snp.bottom)
+            $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
+        bottomButtonStackView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(10)
+            $0.height.equalTo(52)
+        }
+        likeButton.snp.makeConstraints {
+            $0.width.equalTo(75)
+            $0.height.equalToSuperview()
+        }
+        journalButton.snp.makeConstraints {
+            $0.height.equalToSuperview()
+        }
+        coverImageView.snp.makeConstraints {
+            $0.top.equalTo(topView.snp.bottom).offset(16)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(120)
+            $0.height.equalTo(170)
+        }
+        stateFormatStackView.snp.makeConstraints {
+            $0.top.equalTo(coverImageView.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(32)
+        }
+                   
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(stateFormatStackView.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
         }
         authorLabel.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(20)
         }
+        publisherLabel.snp.makeConstraints {
+            $0.top.equalTo(authorLabel.snp.bottom).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+        
+        dateStackView.snp.makeConstraints {
+            $0.top.equalTo(publisherLabel.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+        startDateLabel.snp.makeConstraints {
+            $0.width.equalTo(88)
+            $0.height.equalTo(32)
+            $0.leading.equalTo(dateStackView.snp.leading)
+        }
+        endDateLabel.snp.makeConstraints {
+            $0.width.equalTo(88)
+            $0.height.equalTo(32)
+            $0.trailing.equalTo(dateStackView.snp.trailing)
+        }
+        tagsStackView.snp.makeConstraints {
+            $0.top.equalTo(dateStackView.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.lessThanOrEqualTo(bottomButtonStackView.snp.top).offset(-20)
+        }
+    }
+    
+    private func bind() {
+        topView.backButtonTap
+            .bind { [weak self] in
+                guard let self = self else { return }
+                print("백버튼 눌림")
+                self.navigationController?.popViewController(animated: true)
+            }
+            .disposed(by: disposeBag)
+        // 저널 보기 버튼
+        journalButton.rx.tap
+            .bind { [weak self] in
+                guard let self = self else { return }
+                let journalVC = JournalViewController()
+                self.navigationController?.pushViewController(journalVC, animated: true)
+            }
+            .disposed(by: disposeBag)
+        // 좋아요 버튼
+        likeButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                self?.likeButton.isSelected.toggle()
+                
+                // 추후 데이터 저장 로직 필요
+            })
+            .disposed(by: disposeBag)
     }
     
     private func displayBookInfo() {
         guard let bookData = book else {
-            titleLabel.text = "책 정보를 불러올 수 없습니다"
+            print("책 정보를 불러올 수 없습니다")
             return
         }
+        
+        if let imageData = book?.coverImage, let image = UIImage(data: imageData) {
+            coverImageView.image = image
+        } else {
+            coverImageView.image = nil
+        }
+        if let state = book?.readingState, !state.isEmpty {
+            stateFormatStackView.isHidden = false
+            stateButton.isHidden = false
+            
+            var selectedBgColor: UIColor?
+            var selectedBoarderColor: UIColor?
+            
+            switch state {
+            case "읽는 중":
+                selectedBgColor = .readingSelected
+                selectedBoarderColor = .readingSelected
+            case "중단":
+                selectedBgColor = .finishedSelected
+                selectedBoarderColor = .finishedSelected
+            case "완독":
+                selectedBgColor = .pausedSelected
+                selectedBoarderColor = .pausedSelected
+            case "읽을 예정":
+                selectedBgColor = .scheduledSelected
+                selectedBoarderColor = .scheduledSelected
+            default:
+                stateButton.isHidden = true
+                return
+            }
+            stateButton.configure(title: state, backgroundColor: .stateDefaultBGColor, titleColor: .stateDefaultTextColor, borderColor: selectedBoarderColor ?? .stateDefaultBorderColor, selectedBgColor: selectedBgColor ?? .clear, selectedTitleColor: .stateSeletedTextColor)
+            stateButton.isSelected = true
+            stateButton.isUserInteractionEnabled = false
+        } else {
+            stateButton.isHidden = true
+        }
+        
+        // 책 포맷 버튼
+            if let format = bookData.bookFormat, !format.isEmpty {
+                stateFormatStackView.isHidden = false
+                formatButton.isHidden = false
+                
+                var selectedBgColor: UIColor?
+                var selectedTitleColor: UIColor?
+                
+                switch format {
+                case "종이책":
+                    selectedBgColor = .paperBGColor
+                    selectedTitleColor = .paperTextColor
+                case "전자책":
+                    selectedBgColor = .ebookBGColor
+                    selectedTitleColor = .ebookTextColor
+                default:
+                    formatButton.isHidden = true
+                    return
+                }
+                
+                formatButton.configure(
+                    title: format,
+                    backgroundColor: .formatDefaultBGColor,
+                    titleColor: .formatDefaultTextColor,
+                    borderColor: .formatDefaultBorderColor,
+                    selectedBgColor: selectedBgColor ?? .clear,
+                    selectedTitleColor: selectedTitleColor ?? .black
+                )
+                formatButton.isSelected = true
+                formatButton.isUserInteractionEnabled = false
+                
+            } else {
+                formatButton.isHidden = true
+            }
+        
+        stateFormatStackView.isHidden = stateButton.isHidden && formatButton.isHidden
+        
+        // 책 제목 (필수로 받음)
         titleLabel.text = bookData.title
-        authorLabel.text = bookData.author
+        
+        // 저자
+        if let author = bookData.author, !author.isEmpty {
+            authorLabel.text = author
+            authorLabel.isHidden = false
+        } else {
+            authorLabel.isHidden = true
+        }
+        // 출판사
+        if let publisher = bookData.publisher, !publisher.isEmpty {
+            publisherLabel.text = publisher
+            publisherLabel.isHidden = false
+        } else {
+            publisherLabel.isHidden = true
+        }
+                
+        // 시작일, 종료일
+        let dateFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy.MM.dd"
+            formatter.locale = Locale(identifier: "ko_KR")
+            return formatter
+        }()
+        
+        if let startDate = bookData.startDate {
+            startDateLabel.text = dateFormatter.string(from: startDate)
+            startDateLabel.isHidden = false
+        } else {
+            startDateLabel.text = ""
+            startDateLabel.isHidden = true
+        }
+        if let endDate = bookData.endDate {
+            endDateLabel.text = dateFormatter.string(from: endDate)
+            endDateLabel.isHidden = false
+        } else {
+            endDateLabel.text = ""
+            endDateLabel.isHidden = true
+        }
+        
+        let hasStartDate = (bookData.startDate != nil)
+        let hasEndDate = (bookData.endDate != nil)
+        
+        dateStackView.isHidden = hasStartDate == hasEndDate
+        dateStackView.isHidden = !hasStartDate && !hasEndDate
+        
+        if let tagsString = bookData.selectedTags, !tagsString.isEmpty {
+            setupDetailTags(tagsString: tagsString)
+            tagsStackView.isHidden = false
+        } else {
+            tagsStackView.isHidden = true
+        }
+        view.layoutIfNeeded()
     }
-
+    // 장르 태그 추가
+    private func setupDetailTags(tagsString: String?) {
+        guard let tagsString = tagsString, !tagsString.isEmpty else { return }
+        tagsStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        
+        let tagNames = tagsString.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+        for tagName in tagNames {
+            let tagButton = TagButton(type: .custom)
+            
+            tagButton.configure(
+                title: tagName,
+                titleColor: .tagSeletedTextColor,
+                borderColor: .tagSeletedBoarderColor,
+                selectedBgColor: .tagSeletedBGColor,
+                selectedTitleColor: .tagSeletedTextColor
+            )
+            tagButton.isSelected = true
+            
+            tagsStackView.addArrangedSubview(tagButton)
+        }
+        let spacer = UIView()
+        tagsStackView.addArrangedSubview(spacer)
+    }
+    
 
 }

--- a/UnknownBookArchive/UnknownBookArchive/BookInfo/View/BookInfoViewController.swift
+++ b/UnknownBookArchive/UnknownBookArchive/BookInfo/View/BookInfoViewController.swift
@@ -133,7 +133,7 @@ class BookInfoViewController: UIViewController {
         formatter.locale = Locale(identifier: "ko_KR")
         return formatter
     }()
-
+    
     // 태그 버튼 스택뷰
     private let tagLine1StackView: UIStackView = {
         let stView = UIStackView()
@@ -188,7 +188,8 @@ class BookInfoViewController: UIViewController {
     }
     
     private func configureUI() {
-        view.backgroundColor = .basicBackground
+        view.backgroundColor = .white
+        scrollView.backgroundColor = .basicBackground
         [topView, scrollView ].forEach { view.addSubview($0) }
         [contentView].forEach { scrollView.addSubview($0) }
         [
@@ -445,16 +446,16 @@ class BookInfoViewController: UIViewController {
     }
     
     private func findFirstResponder(in view: UIView) -> UIResponder? {
-            if view.isFirstResponder {
-                return view
-            }
-            for subview in view.subviews {
-                if let responder = findFirstResponder(in: subview) {
-                    return responder
-                }
-            }
-            return nil
+        if view.isFirstResponder {
+            return view
         }
+        for subview in view.subviews {
+            if let responder = findFirstResponder(in: subview) {
+                return responder
+            }
+        }
+        return nil
+    }
     
     @objc
     private func tagButtonTapped(_ sender: TagButton) {
@@ -579,7 +580,7 @@ class BookInfoViewController: UIViewController {
             popover.sourceRect = sourceButton.bounds
             popover.permittedArrowDirections = [.up, .down]
         }
-  
+        
         // 달력 만들기
         let datePicker = UIDatePicker()
         datePicker.datePickerMode = .date
@@ -619,7 +620,6 @@ class BookInfoViewController: UIViewController {
         self.present(calenderVC, animated: true)
     }
     
-    
     private func setupTagButtons() {
         // 모든 태그 버튼을 배열로 묶어서 설정 코드를 재사용합니다. (DRY 원칙)
         let allTagButtons: [TagButton] = [
@@ -627,7 +627,7 @@ class BookInfoViewController: UIViewController {
             tagButton5, tagButton6, tagButton7, tagButton8, tagButton9,
             tagButton10
         ]
-
+        
         for (index, button) in allTagButtons.enumerated() {
             guard index < tags.count else { continue }
             let title = tags[index].rawValue
@@ -644,11 +644,11 @@ class BookInfoViewController: UIViewController {
             button.addTarget(self, action: #selector(tagButtonTapped), for: .touchUpInside)
         }
         [tagButton0, tagButton1, tagButton2, tagButton3, tagButton4]
-                .forEach { tagLine1StackView.addArrangedSubview($0) }
+            .forEach { tagLine1StackView.addArrangedSubview($0) }
         [tagButton5, tagButton6, tagButton7, tagButton8, tagButton9]
-                .forEach { tagLine2StackView.addArrangedSubview($0) }
+            .forEach { tagLine2StackView.addArrangedSubview($0) }
         [tagButton10]
-                .forEach { tagLine3StackView.addArrangedSubview($0) }
+            .forEach { tagLine3StackView.addArrangedSubview($0) }
         
     }
     
@@ -691,14 +691,20 @@ class BookInfoViewController: UIViewController {
             uuid: newUUID, title: title, author: author, publisher: publisher, readingState: readingState, bookFormat: bookFormat, selectedTags: selectedTagsString, coverImage: coverImageData, currentPage: currentPage, totalPage: totalPage, percent: percent, startDate: startDate, endDate: endDate)
         
         if let saveBook = savedBook {
-            let detailVC = BookDetailViewController()
-            detailVC.book = saveBook
-            
-            self.navigationController?.pushViewController(detailVC, animated: true)
-        } else {
-            print("저장 실패. 알럿 처리필요")
+                let detailVC = BookDetailViewController()
+                detailVC.book = saveBook
+                detailVC.hidesBottomBarWhenPushed = false
+
+                if let navigationController = self.navigationController {
+                    var viewConrollers = navigationController.viewControllers
+                    viewConrollers.removeLast()
+                    viewConrollers.append(detailVC)
+                
+                    navigationController.setViewControllers(viewConrollers, animated: true)
+                }
+            } else {
+                print("저장 실패. 알럿 처리필요")
+            }
         }
-        
-    }
-}
     
+}

--- a/UnknownBookArchive/UnknownBookArchive/BookSearch/View/BookSearchViewController.swift
+++ b/UnknownBookArchive/UnknownBookArchive/BookSearch/View/BookSearchViewController.swift
@@ -208,7 +208,7 @@ class BookSearchViewController: UIViewController {
             button.setTitle("직접 책 추가하기", for: .normal)
             button.setTitleColor(.white, for: .normal)
             button.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
-            button.layer.cornerRadius = 5
+            button.layer.cornerRadius = 8
             
             stackView.addArrangedSubview(button)
             button.snp.makeConstraints {
@@ -237,6 +237,7 @@ class BookSearchViewController: UIViewController {
         let bookInfoVM = BookInfoViewModel()
         bookInfoVC.viewModel = bookInfoVM
         bookInfoVM.initialBookItem.onNext(emptyBookItem)
+        bookInfoVC.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(bookInfoVC, animated: true)
     }
 }


### PR DESCRIPTION
## ☄️Pull Request

이슈번호 #42 

## 💬 작업 내용 + 변경 사항

-  책 저장 후 상세페이지 구현 
-  진행률 바 + 우상단 버튼 제외한 레이아웃 구현
- 책 기록 후 상세페이지에서 백버튼 누르면 검색페이지로 이동
- 저널보기 버튼 누르면 저널페이지로 이동
- 탭바의 홈버튼 누르면 어디서든 홈으로 이동 됨
- 상단 내비게이션 바와 노치부분 색 다른 거 수정 됨


## 📷 구현
![feat#42](https://github.com/user-attachments/assets/a748488b-51ea-4003-b2e0-d126c53cc21f)

## :클립: 레퍼런스

## Close Issue

Close #42 

# :두꺼운_확인_표시:Checklist

- [ ✅ ] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [ ✅ ] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [ ✅] 필요없는 주석, 프린트문 제거했는지 확인
- [ ✅ ] 컨벤션 지켰는지 확인
- [ ✅ ] final, private 제대로 넣었는지 확인
- [ ✅ ] 다양한 디바이스에 레이아웃이 대응되는지 확인