### PR TITLE
[feat] #55 책 썸네일 클릭 시 책상세 화면으로

### DIFF
--- a/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/ReadingHomeViewController.swift
+++ b/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/ReadingHomeViewController.swift
@@ -456,6 +456,24 @@ extension ReadingHomeViewController: UICollectionViewDataSource, UICollectionVie
         
         return cell
     }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+        let book: Book
+        
+        if collectionView == plannedCollectionView {
+            book = plannedBooks[indexPath.item]
+        } else if collectionView == pausedCollectionView {
+            book = pausedBooks[indexPath.item]
+        } else {
+            book = finishedBooks[indexPath.item]
+        }
+        
+        let detailVC = BookDetailViewController()
+        detailVC.book = book
+        navigationController?.pushViewController(detailVC, animated: true)
+    }
+
 }
 
 


### PR DESCRIPTION
## ☄️Pull Request

이슈번호 #55 

## 💬 작업 내용 + 변경 사항

- 메인 화면에 있는 썸네일 클릭 시 책 상세화면으로 넘어갑니다.
- 상세화면 속 저널을 눌렀을 때 저널화면으로 넘어가는 것도 확인했습니다.
- 더보기 버튼을 눌렀을 때 나오는 화면은 아직 구현 못했습니다.


## 📷 구현
![ScreenRecording_11-30-2025 20-09-28_1](https://github.com/user-attachments/assets/1ba610f5-9fde-4fe4-bde2-a33eb31173ea)


## :클립: 레퍼런스

## Close Issue

Close #55 

# :두꺼운_확인_표시:Checklist

- [ ✅ ] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [ ✅ ] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [ ✅] 필요없는 주석, 프린트문 제거했는지 확인
- [ ✅ ] 컨벤션 지켰는지 확인
- [ ✅ ] final, private 제대로 넣었는지 확인
- [ ✅ ] 다양한 디바이스에 레이아웃이 대응되는지 확인