### PR TITLE
[feat] #103 책표지 고화질 이미지 API 불러오기

### DIFF
--- a/UnknownBookArchive/UnknownBookArchive/BookInfo/View/BookInfoViewController.swift
+++ b/UnknownBookArchive/UnknownBookArchive/BookInfo/View/BookInfoViewController.swift
@@ -331,24 +331,35 @@ class BookInfoViewController: UIViewController, UIImagePickerControllerDelegate 
         viewModel.coverImageUrl
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] urlString in
-                if let urlString = urlString, let url = URL(string: urlString) {
-                    self?.plusIconImage.isHidden = true
-                    URLSession.shared.dataTask(with: url) { data, response, error in
-                        guard let data = data, let image = UIImage(data: data), error == nil else {
-                            DispatchQueue.main.async {
-                                self?.coverImageView.image = nil
-                                self?.plusIconImage.isHidden = false
-                            }
-                            return
-                        }
-                        DispatchQueue.main.async {
-                            self?.coverImageView.image = image
-                        }
-                    }.resume()
-                } else {
-                    self?.coverImageView.image = nil
-                    self?.plusIconImage.isHidden = false
+                guard let self = self else { return }
+                
+                if let urlString = urlString, !urlString.hasPrefix("http") {
+                    self.plusIconImage.isHidden = (self.coverImageView.image != nil)
+                    return
                 }
+                if let urlString = urlString {
+                    
+                    let highQualityURLString = urlString.replacingOccurrences(of: "/coversum/", with: "/cover200/")
+                    if let url = URL(string: highQualityURLString) {
+                        self.plusIconImage.isHidden = true
+                        self.coverImageView.image = nil
+                        URLSession.shared.dataTask(with: url) { data, response, error in
+                            guard let data = data, let image = UIImage(data: data), error == nil else {
+                                DispatchQueue.main.async {
+                                    self.coverImageView.image = nil
+                                    self.plusIconImage.isHidden = false
+                                }
+                                return
+                            }
+                            DispatchQueue.main.async {
+                                self.coverImageView.image = image
+                            }
+                        }.resume()
+                        return
+                    }
+                }
+                self.coverImageView.image = nil
+                self.plusIconImage.isHidden = false
             })
             .disposed(by: disposeBag)
         
@@ -678,13 +689,12 @@ class BookInfoViewController: UIViewController, UIImagePickerControllerDelegate 
         }
     }
     
-    
     // MARK: 코어데이터 관련 함수
     // 저장 버튼에 들어갈 함수
     private func saveBookInfo() {
         
         // 데이터 추출-----------------------------------------
-        let coverImageData = coverImageView.image?.jpegData(compressionQuality: 0.8)
+        let coverImageData = coverImageView.image?.jpegData(compressionQuality: 1.0)
         
         let readingState = selectedStateButton?.title(for: .normal) ?? ""
         let bookFormat = selectedFormatButton?.title(for: .normal) ?? ""
@@ -819,9 +829,16 @@ class BookInfoViewController: UIViewController, UIImagePickerControllerDelegate 
         
         if let imageData = book.coverImage, let image = UIImage(data: imageData) {
             coverImageView.image = image
+            if let isbn = book.isbn {
+                viewModel.coverImageUrl.accept(isbn)
+            } else {
+                viewModel.coverImageUrl.accept("CoreDataImageExists")
+            }
         } else {
             coverImageView.image = nil
+            viewModel.coverImageUrl.accept(nil)
         }
+        self.plusIconImage.isHidden = false
         
         if let state = book.readingState {
             let stateButtons: [BaseButton] = [readingButton, pausedButton, finishedButton, scheduledButton]

--- a/UnknownBookArchive/UnknownBookArchive/BookSearch/View/BookSearchCell.swift
+++ b/UnknownBookArchive/UnknownBookArchive/BookSearch/View/BookSearchCell.swift
@@ -6,6 +6,8 @@ import SnapKit
 class BookSearchCell: UITableViewCell {
     static let id = "BookSearchCell"
     
+    private var dataTask: URLSessionDataTask?
+    
     private let thumnailImage: UIImageView = {
         let imageView = UIImageView()
         imageView.backgroundColor = .white
@@ -94,18 +96,28 @@ class BookSearchCell: UITableViewCell {
         self.authorLabel.text = item.author
         self.publisherLabel.text = item.publisher
         
-        if let imageURL = URL(string: item.cover) {
-            self.thumnailImage.image = nil
-            
-            URLSession.shared.dataTask(with: imageURL) { [weak self] data, _, error in
+        self.dataTask?.cancel()
+        self.thumnailImage.image = nil
+        
+        if let imageURL = URL(string: item.highQualityCover) {
+            let newTask = URLSession.shared.dataTask(with: imageURL) { [weak self] data, _, error in
+                if let error = error as? URLError, error.code == .cancelled {
+                    return
+                }
                 guard let data = data, error == nil else {
-                    print("이미지 불러오기 실패")
+                    print("이미지 불러오기 실패: \(error?.localizedDescription ?? "알 수 없는 에러")")
                     return
                 }
                 DispatchQueue.main.async {
                     self?.thumnailImage.image = UIImage(data: data)
                 }
-            }.resume()
+                self?.dataTask = nil
+                
+            }
+            self.dataTask = newTask
+            newTask.resume()
+        } else {
+            self.dataTask = nil
         }
     }
 }

--- a/UnknownBookArchive/UnknownBookArchive/Model/BookResponse.swift
+++ b/UnknownBookArchive/UnknownBookArchive/Model/BookResponse.swift
@@ -14,6 +14,9 @@ struct BookItem: Decodable {
     let isbn: String?
     let isbn13: String?
     
+    var highQualityCover: String {
+        return self.cover.replacingOccurrences(of: "/coversum/", with: "/cover200/")
+    }
     // 직접 책 추가 시 초기화 용
     static func empty() -> BookItem {
         return BookItem(title: "", author: "", publisher: "", cover: "", isbn: nil, isbn13: nil)


### PR DESCRIPTION
## ☄️Pull Request

이슈번호 #103 

## 💬 작업 내용 + 변경 사항

- 책표지 고화질 이미지 API불러오기 및 UI 반영
- 코어데이터 저장해도 고화질로 저장되도록 수정

## 📷 구현
<img src="https://github.com/user-attachments/assets/81bfe23b-d071-4e70-926b-203c2e5738c2" width="40%">
<img src="https://github.com/user-attachments/assets/251b3d7b-3d70-48fe-9a9e-960d3f8424a5" width="40%">

좋아요에서 두번째 책이 기존 화질입니다. (비교용)
## 📎 레퍼런스

## Close Issue

Close #103 

# ✔️Checklist

- [ ✅ ] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [ ✅ ] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [ ✅] 필요없는 주석, 프린트문 제거했는지 확인
- [ ✅ ] 컨벤션 지켰는지 확인
- [ ✅ ] final, private 제대로 넣었는지 확인
- [ ✅ ] 다양한 디바이스에 레이아웃이 대응되는지 확인