### PR TITLE
[bug] #139 좋아요 한 문단수집 정렬 수정

### DIFF
--- a/UnknownBookArchive/UnknownBookArchive/Journal/Paragraph/ViewModel/ParagraphListViewModel.swift
+++ b/UnknownBookArchive/UnknownBookArchive/Journal/Paragraph/ViewModel/ParagraphListViewModel.swift
@@ -70,11 +70,19 @@ final class ParagraphListViewModel {
     func toggleLike(at index: Int) {
         let journal = journals[index]
         journal.liked.toggle()
+        
+        if journal.liked {
+            journal.likedDate = Date()
+        } else {
+            journal.likedDate = nil
+        }
+ 
         do {
             try context.save()
             onUpdate?()
         } catch {
             journal.liked.toggle()
+            journal.likedDate = nil
         }
     }
     

--- a/UnknownBookArchive/UnknownBookArchive/LikeCollection/LikeParagraph/ViewModel/LikeParagraphViewModel.swift
+++ b/UnknownBookArchive/UnknownBookArchive/LikeCollection/LikeParagraph/ViewModel/LikeParagraphViewModel.swift
@@ -30,7 +30,7 @@ final class LikeParagraphViewModel {
     func fetchParagraphs() {
         let request: NSFetchRequest<Journal> = Journal.fetchRequest()
         // 최신순 정렬
-        let sort = NSSortDescriptor(key: "createDate", ascending: false)
+        let sort = NSSortDescriptor(key: "likedDate", ascending: false)
         request.sortDescriptors = [sort]
         do {
             journals = try context.fetch(request)
@@ -43,7 +43,7 @@ final class LikeParagraphViewModel {
         let request: NSFetchRequest<Journal> = Journal.fetchRequest()
         request.predicate = NSPredicate(format: "liked == true")
         
-        let sort = NSSortDescriptor(key: "createDate", ascending: false)
+        let sort = NSSortDescriptor(key: "likedDate", ascending: false)
         request.sortDescriptors = [sort]
         
         do {
@@ -101,6 +101,11 @@ final class LikeParagraphViewModel {
         let journal = likedParagraphs[index]
         journal.liked.toggle()
         
+        if journal.liked {
+            journal.likedDate = Date()
+        } else {
+            journal.likedDate = nil
+        }
      
         
         do {


### PR DESCRIPTION
## Pull Request
이슈번호 #139
## 작업 내용 + 변경 사항
- 좋아요 한 문단수집이 추가된 순이 아닌 저장된 날짜순으로 정렬되는 문제를 해결했습니다.

## 구현 이미지
<img width="603" height="1311" alt="스크린샷, 2025-12-09 오후 8 21 32" src="https://github.com/user-attachments/assets/f9f93c3b-0d89-4325-8418-f757f36713b6" />


## 레퍼런스
## Close Issue
Close #139
