### PR TITLE
[feat] #129 메인화면에서 진행률 수정하는 기능

### DIFF
--- a/UnknownBookArchive/UnknownBookArchive/1.ReuseView/BaseAlert.swift
+++ b/UnknownBookArchive/UnknownBookArchive/1.ReuseView/BaseAlert.swift
@@ -11,6 +11,7 @@ extension UIViewController {
         confirmTitle: String = "확인",
         completion: (() -> Void)? = nil
     ) {
+        
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         
         let confirmAction = UIAlertAction(title: confirmTitle, style: .default) { _ in

--- a/UnknownBookArchive/UnknownBookArchive/BookInfo/View/BookInfoViewController.swift
+++ b/UnknownBookArchive/UnknownBookArchive/BookInfo/View/BookInfoViewController.swift
@@ -8,7 +8,7 @@ import RxKeyboard
 import CoreData
 import Photos
 
-class BookInfoViewController: UIViewController, UIImagePickerControllerDelegate & UINavigationControllerDelegate {
+class BookInfoViewController: UIViewController, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     
     var viewModel = BookInfoViewModel()
     var book: Book?
@@ -487,7 +487,7 @@ class BookInfoViewController: UIViewController, UIImagePickerControllerDelegate 
     
     // MARK: UI setup 함수들
     private func setupTopView() {
-        let saveConfig = UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold)
+        let saveConfig = UIImage.SymbolConfiguration(pointSize: 20, weight: .semibold)
         let saveImage = UIImage(systemName: "checkmark.circle.fill", withConfiguration: saveConfig)
         topView.configure(title: "", rightButtonImage: saveImage)
     }

--- a/UnknownBookArchive/UnknownBookArchive/Model/CoreDataManager.swift
+++ b/UnknownBookArchive/UnknownBookArchive/Model/CoreDataManager.swift
@@ -424,4 +424,34 @@ class CoreDataManager {
             return 0
         }
     }
+    // MARK: 진행도 수정
+    func updateProgress(uuid: String, isPageMode: Bool, currentPage: Int32, totalPage: Int32, percent: Int32, lastModifiedDate: Date) ->Bool {
+        let fetchRequest: NSFetchRequest<Book> = Book.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "uuid == %@", uuid)
+         
+        do {
+            let results = try context.fetch(fetchRequest)
+            guard let bookToUpdate = results.first else {
+                return false
+            }
+            bookToUpdate.isPageMode = isPageMode
+            bookToUpdate.lastModifiedDate = lastModifiedDate
+            
+            if isPageMode {
+                bookToUpdate.currentPage = currentPage
+                bookToUpdate.totalPage = totalPage
+                
+            } else {
+                bookToUpdate.percent = percent
+            }
+            if context.hasChanges {
+                try context.save()
+                return true
+            } else {
+                return true
+            }
+        } catch {
+            return false
+        }
+    }
 }

--- a/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/CurrentReadingCell.swift
+++ b/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/CurrentReadingCell.swift
@@ -2,10 +2,14 @@
 
 import UIKit
 import SnapKit
+import RxSwift
 
 final class CurrentReadingCell: UICollectionViewCell {
     
     static let identifier = "CurrentReadingCell"
+    let disposeBag = DisposeBag()
+    private var book: Book?
+    
     
     // MARK: - UI 요소
     let thumbnailImageView = UIImageView()
@@ -15,7 +19,8 @@ final class CurrentReadingCell: UICollectionViewCell {
     let percentLabel = UILabel()
     let progressBar = UIProgressView()
     let journalButton = UIButton(type: .system)
-
+    let progressEditView = UIView()
+    
     // 날짜 + 진행률 스택
     private let dateInfoStack: UIStackView = {
         let st = UIStackView()
@@ -27,6 +32,8 @@ final class CurrentReadingCell: UICollectionViewCell {
     
     // 저널 버튼 콜백
     var onJournalButtonTapped: (() -> Void)?
+    // 진행률 수정 콜백
+    var onProgressEditTapped: ((Book) -> Void)?
     
     
     // MARK: - Init
@@ -34,11 +41,11 @@ final class CurrentReadingCell: UICollectionViewCell {
         super.init(frame: frame)
         setupUI()
         setupLayout()
-
+        
         contentView.backgroundColor = .clear
         contentView.layer.cornerRadius = 0
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -84,6 +91,11 @@ final class CurrentReadingCell: UICollectionViewCell {
         journalButton.titleLabel?.font = UIFont.mediumFont(ofSize: 12)
         journalButton.layer.cornerRadius = 4
         journalButton.addTarget(self, action: #selector(didTapJournal), for: .touchUpInside)
+        
+        // 프로그레스바 탭 제스처
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapProgressBar))
+        progressEditView.addGestureRecognizer(tapGesture)
+        progressEditView.isUserInteractionEnabled = true
     }
     
     
@@ -94,13 +106,17 @@ final class CurrentReadingCell: UICollectionViewCell {
         contentView.addSubview(thumbnailImageView)
         contentView.addSubview(titleLabel)
         contentView.addSubview(authorLabel)
-        contentView.addSubview(dateInfoStack)
-        contentView.addSubview(progressBar)
+        //        contentView.addSubview(dateInfoStack)
+        //        contentView.addSubview(progressBar)
+        contentView.addSubview(progressEditView)
         contentView.addSubview(journalButton)
         
         // 날짜 + 진행률 스택 내부에 라벨 넣기
         dateInfoStack.addArrangedSubview(dateLabel)
         dateInfoStack.addArrangedSubview(percentLabel)
+        
+        // 날짜 + 진행률 + 프로그레스바
+        [dateInfoStack, progressBar].forEach{ progressEditView.addSubview($0) }
         
         
         // 썸네일
@@ -122,25 +138,32 @@ final class CurrentReadingCell: UICollectionViewCell {
             $0.leading.equalTo(titleLabel)
             $0.trailing.equalToSuperview().inset(16)
         }
-        
-        // 날짜 + 진행률
-        dateInfoStack.snp.makeConstraints {
+        progressEditView.snp.makeConstraints {
             $0.top.equalTo(authorLabel.snp.bottom).offset(16)
             $0.leading.equalTo(titleLabel)
             $0.trailing.equalToSuperview().inset(16)
         }
         
+        
+        // 날짜 + 진행률
+        dateInfoStack.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            //            $0.top.equalTo(authorLabel.snp.bottom).offset(16)
+            //            $0.leading.equalTo(titleLabel)
+            //            $0.trailing.equalToSuperview().inset(16)
+        }
+        
         // 진행률 바
         progressBar.snp.makeConstraints {
             $0.top.equalTo(dateInfoStack.snp.bottom).offset(4)
-            $0.leading.equalTo(titleLabel)
-            $0.trailing.equalToSuperview().inset(16)
+            $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(6)
+            $0.bottom.equalToSuperview()
         }
         
         // 저널 버튼
         journalButton.snp.makeConstraints {
-            $0.top.equalTo(progressBar.snp.bottom).offset(16)
+            $0.top.equalTo(progressEditView.snp.bottom).offset(16)
             $0.trailing.equalToSuperview().inset(16)
             $0.leading.equalTo(titleLabel)
             $0.height.equalTo(32)
@@ -159,10 +182,11 @@ final class CurrentReadingCell: UICollectionViewCell {
         percentLabel.text = nil
         progressBar.progress = 0
     }
-
+    
     
     // MARK: - 데이터 구성
     func configure(with book: Book) {
+        self.book = book
         
         titleLabel.text = book.title
         authorLabel.text = book.author
@@ -186,10 +210,16 @@ final class CurrentReadingCell: UICollectionViewCell {
         let totalPage = Int(book.totalPage)
         let percent = Int(book.percent)
         
-        if totalPage > 0 {
-            let progress = Float(currentPage) / Float(totalPage)
-            progressBar.progress = progress
-            percentLabel.text = "\(currentPage)/\(totalPage) P"
+        if book.isPageMode {
+            if totalPage > 0 {
+                let progress = Float(currentPage) / Float(totalPage)
+                progressBar.progress = progress
+                percentLabel.text = "\(currentPage)/\(totalPage) P"
+            } else {
+                progressBar.progress = 0.0
+                percentLabel.text = "0/0 P"
+            }
+        
         } else {
             let clamped = max(0, min(percent, 100))
             progressBar.progress = Float(clamped) / 100.0
@@ -201,5 +231,11 @@ final class CurrentReadingCell: UICollectionViewCell {
     // MARK: - Action
     @objc private func didTapJournal() {
         onJournalButtonTapped?()
+    }
+    // 진행률 탭 액션
+    @objc private func didTapProgressBar() {
+        print("진행률 바 눌림")
+        guard let book = self.book else { return }
+        onProgressEditTapped?(book)
     }
 }

--- a/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/ProgressEditViewController.swift
+++ b/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/ProgressEditViewController.swift
@@ -1,0 +1,197 @@
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+import CoreData
+
+
+class ProgressEditViewController: UIViewController {
+    
+    private let disposeBag = DisposeBag()
+    var book: Book
+    var completion: ((Book) -> Void)?
+    
+    // MARK: UI
+    private let topView = TopView()
+    private let progressStackView: UIStackView = {
+        let stView = UIStackView()
+        stView.axis = .horizontal
+        stView.spacing = 12
+        stView.alignment = .center
+        return stView
+    }()
+    
+    private let toggleButton = ToggleButton()
+    private let pageTextField = BaseTextField()
+    private let totalPageTextField = BaseTextField()
+    private let percentTextField = BaseTextField()
+ 
+    private let inputStackView: UIStackView = {
+        let st = UIStackView()
+        st.axis = .horizontal
+        st.spacing = 8
+        st.distribution = .fillEqually
+        return st
+    }()
+    
+    init(book: Book) {
+            self.book = book
+            super.init(nibName: nil, bundle: nil)
+        }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        configureUI()
+        setConstraints()
+        setupTopView()
+        setupProgressUI()
+        setupUIWithExistingBook()
+        bind()
+        
+    }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+    
+    private func configureUI() {
+        [topView, progressStackView].forEach { view.addSubview($0) }
+        [inputStackView, toggleButton].forEach { progressStackView.addArrangedSubview($0) }
+
+    }
+    
+    private func setConstraints() {
+        topView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(60)
+            $0.leading.trailing.equalToSuperview()
+        }
+        progressStackView.snp.makeConstraints {
+            $0.top.equalTo(topView.snp.bottom).offset(30)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+        inputStackView.snp.makeConstraints {
+            $0.height.equalTo(40)
+        }
+ 
+        toggleButton.snp.makeConstraints {
+            $0.width.equalTo(51)
+            $0.height.equalTo(40)
+        }
+    }
+    
+    private func setupTopView() {
+        let saveConfig = UIImage.SymbolConfiguration(pointSize: 20, weight: .semibold)
+        let saveImage = UIImage(systemName: "checkmark.circle.fill", withConfiguration: saveConfig)
+        topView.configure(title: "진행률 수정", rightButtonImage: saveImage)
+    }
+    
+    private func setupProgressUI() {
+        pageTextField.configure(placeholder: "읽은 페이지")
+        totalPageTextField.configure(placeholder: "전체 페이지")
+        percentTextField.configure(placeholder: "진행률을 입력하세요")
+        toggleButton.configure(initialPageMode: true)
+        pageTextField.keyboardType = .numberPad
+        totalPageTextField.keyboardType = .numberPad
+        percentTextField.keyboardType = .numberPad
+    }
+    private func bind() {
+        topView.rightButtonTap
+            .asSignal(onErrorJustReturn: ())
+            .emit(onNext: { [weak self] in
+                self?.saveBookProgress()
+            })
+            .disposed(by: disposeBag)
+        
+        topView.backButtonTap
+            .asSignal(onErrorJustReturn: ())
+            .emit(onNext: { [weak self] in
+                self?.dismiss(animated: true)
+            })
+            .disposed(by: disposeBag)
+        
+        toggleButton.rx.controlEvent(.valueChanged)
+            .bind { [weak self] in
+                self?.handleToggleTap()
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    // 페이지, 퍼센트 모드 토글 버튼 탭
+    private func handleToggleTap() {
+        let isPageMode = toggleButton.isPageMode
+        
+        inputStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        
+        if isPageMode {
+            [pageTextField, totalPageTextField].forEach { inputStackView.addArrangedSubview($0) }
+            inputStackView.distribution = .fillEqually
+        } else {
+            inputStackView.addArrangedSubview(percentTextField)
+            inputStackView.distribution = .fill
+        }
+        UIView.animate(withDuration: 0.3) {
+            self.view.layoutIfNeeded()
+        }
+    }
+    
+    private func setupUIWithExistingBook() {
+        toggleButton.isPageMode = book.isPageMode
+        pageTextField.text = (book.currentPage > 0) ? String(book.currentPage) : nil
+        totalPageTextField.text = (book.totalPage > 0) ? String(book.totalPage) : nil
+        percentTextField.text = (book.percent > 0) ? String(book.percent) : nil
+        handleToggleTap()
+    }
+    
+    private func saveBookProgress() {
+        let isPageMode = toggleButton.isPageMode
+        // 페이지 수
+        let currentPage = Int32(pageTextField.text ?? "0") ?? 0
+        let totalPage = Int32(totalPageTextField.text ?? "0") ?? 0
+        
+        let maxPageValue: Int32 = 9999
+        
+        if totalPage > maxPageValue || currentPage > maxPageValue {
+            showAlert(title: "페이지 입력 오류", message: "페이지 수는 9,999페이지를 초과할 수 없습니다.")
+            return
+        }
+        
+        if totalPage > 0 && currentPage > totalPage {
+            showAlert(title: "페이지 입력 오류", message: "읽은 페이지가 전체 페이지보다 클 수 없습니다.")
+            return
+        }
+        
+        let percentText = percentTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let percent = Int32(percentText) ?? 0
+        if !percentText.isEmpty && (percent < 0 || percent > 100) {
+            showAlert(title: "진행률 입력 오류", message: "0부터 100 사이의 값만 입력할 수 있습니다.")
+            return
+        }
+        
+        // CoreData 수정
+        guard let exsitingUUID = self.book.uuid else {
+            showAlert(title: "오류", message: "책을 찾을 수 없습니다.")
+            return
+        }
+        self.book.isPageMode = isPageMode
+        self.book.currentPage = currentPage
+        self.book.totalPage = totalPage
+        self.book.percent = percent
+        
+        let isSuccess = CoreDataManager.shared.updateProgress(uuid: exsitingUUID, isPageMode: isPageMode, currentPage: currentPage, totalPage: totalPage, percent: percent, lastModifiedDate: Date())
+        if isSuccess {
+            self.completion?(self.book)
+            self.dismiss(animated: true, completion: nil)
+        } else {
+            showAlert(title: "저장 실패", message: "책 진행률 수정에 실패했습니다.")
+        }
+
+    }
+
+}
+

--- a/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/ReadingHomeViewController.swift
+++ b/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/ReadingHomeViewController.swift
@@ -2,10 +2,12 @@
 
 import UIKit
 import SnapKit
+import RxSwift
 
 final class ReadingHomeViewController: UIViewController {
     
     private let viewModel = ReadingHomeViewModel()
+    private let disposeBag = DisposeBag()
     
     private let scrollView = UIScrollView()     // 전체 스크롤
     private let contentStackView = UIStackView()    // 콘텐츠 전체 스택
@@ -617,33 +619,35 @@ extension ReadingHomeViewController: UICollectionViewDataSource, UICollectionVie
             
             let book = currentReadingBooks[indexPath.item]
             
-            cell.titleLabel.text = book.title
-            cell.authorLabel.text = book.author
+            cell.configure(with: book)
             
-            if let imgData = book.coverImage,
-               let image = UIImage(data: imgData) {
-                cell.thumbnailImageView.image = image
-            }
-            
-            if let startDate = book.startDate {
-                let df = DateFormatter()
-                df.dateFormat = "yyyy.MM.dd"
-                cell.dateLabel.text = df.string(from: startDate)
-            }
-            
-            let currentPage = Int(book.currentPage)
-            let totalPage = Int(book.totalPage)
-            let percent = Int(book.percent)
-            
-            if totalPage > 0 {
-                cell.progressBar.progress = Float(currentPage) / Float(totalPage)
-                cell.percentLabel.text = "\(currentPage)/\(totalPage) P"
-                
-            } else {
-                let clamped = max(0, min(percent, 100))
-                cell.progressBar.progress = Float(clamped) / 100
-                cell.percentLabel.text = "\(clamped)%"
-            }
+//            cell.titleLabel.text = book.title
+//            cell.authorLabel.text = book.author
+//            
+//            if let imgData = book.coverImage,
+//               let image = UIImage(data: imgData) {
+//                cell.thumbnailImageView.image = image
+//            }
+//            
+//            if let startDate = book.startDate {
+//                let df = DateFormatter()
+//                df.dateFormat = "yyyy.MM.dd"
+//                cell.dateLabel.text = df.string(from: startDate)
+//            }
+//            
+//            let currentPage = Int(book.currentPage)
+//            let totalPage = Int(book.totalPage)
+//            let percent = Int(book.percent)
+//            
+//            if totalPage > 0 {
+//                cell.progressBar.progress = Float(currentPage) / Float(totalPage)
+//                cell.percentLabel.text = "\(currentPage)/\(totalPage) P"
+//                
+//            } else {
+//                let clamped = max(0, min(percent, 100))
+//                cell.progressBar.progress = Float(clamped) / 100
+//                cell.percentLabel.text = "\(clamped)%"
+//            }
             
             cell.onJournalButtonTapped = { [weak self] in
                 let vc = JournalViewController(book: book)
@@ -652,7 +656,21 @@ extension ReadingHomeViewController: UICollectionViewDataSource, UICollectionVie
 
                 self?.navigationController?.pushViewController(vc, animated: true)
             }
-            
+            cell.onProgressEditTapped = { [weak self, weak cell] bookToEdit in
+                let editVC = ProgressEditViewController(book: bookToEdit)
+                let navigationController = UINavigationController(rootViewController: editVC)
+                    navigationController.modalPresentationStyle = .pageSheet
+                    if let sheet = navigationController.sheetPresentationController {
+                        sheet.detents = [.medium(), .large()]
+                    }
+                editVC.completion = { [weak self, weak cell] updatedBook in
+                    cell?.configure(with: updatedBook)
+                    if let index = self?.currentReadingBooks.firstIndex(where: { $0.uuid == updatedBook.uuid }) {
+                                self?.currentReadingBooks[index] = updatedBook
+                            }
+                        }
+                self?.present(navigationController, animated: true)
+            }
             return cell
         }
         
@@ -679,7 +697,6 @@ extension ReadingHomeViewController: UICollectionViewDataSource, UICollectionVie
         
         return cell
     }
-    
     
     func collectionView(_ collectionView: UICollectionView,
                         didSelectItemAt indexPath: IndexPath) {


### PR DESCRIPTION
## ☄️Pull Request

이슈번호 #129 

## 💬 작업 내용 + 변경 사항

- 메인화면 진행바 눌러서 진행률 수정
- 처음부터 모달뷰가 전체화면 채우면 너무 휑한거 같아서 미디움으로 했다가 키보드 올라올때 라지로 올라오도록 했습니다
- ReadingHomeVC 624~650 줄 중복 로직인 것 같아서 주석 처리해뒀는데 지금은 문제 없이 잘 돌아갑니다.
  이후에도 문제 없으면 삭제해도 될 것 같아요

## 📷 구현
![feat#129](https://github.com/user-attachments/assets/c8686eab-7b49-4704-b37f-1754f28b687a)

## 📎 레퍼런스

## Close Issue

Close #129 

# ✔️Checklist

- [ ✅ ] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [ ✅ ] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [ ✅] 필요없는 주석