### PR TITLE
[design] #143 메인화면 현재 읽는 책 UI레이아웃 조정

### DIFF
--- a/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/CurrentReadingCell.swift
+++ b/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/CurrentReadingCell.swift
@@ -129,28 +129,29 @@ final class CurrentReadingCell: UICollectionViewCell {
         titleLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(23)
             $0.leading.equalTo(thumbnailImageView.snp.trailing).offset(16)
-            $0.trailing.equalToSuperview().inset(16)
+            $0.trailing.equalToSuperview().inset(8)
         }
         
         // 작가
         authorLabel.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(4)
             $0.leading.equalTo(titleLabel)
-            $0.trailing.equalToSuperview().inset(16)
+            $0.trailing.equalToSuperview().inset(8)
+            
         }
         progressEditView.snp.makeConstraints {
-            $0.top.equalTo(authorLabel.snp.bottom).offset(16)
+            $0.top.equalTo(authorLabel.snp.bottom).offset(6)
             $0.leading.equalTo(titleLabel)
-            $0.trailing.equalToSuperview().inset(16)
+            $0.trailing.equalToSuperview().inset(8)
+            $0.height.equalTo(40)
         }
         
         
         // 날짜 + 진행률
         dateInfoStack.snp.makeConstraints {
-            $0.top.leading.trailing.equalToSuperview()
-            //            $0.top.equalTo(authorLabel.snp.bottom).offset(16)
-            //            $0.leading.equalTo(titleLabel)
-            //            $0.trailing.equalToSuperview().inset(16)
+            $0.top.equalTo(progressEditView.snp.top).offset(10)
+            $0.leading.trailing.equalToSuperview()
+
         }
         
         // 진행률 바
@@ -158,13 +159,12 @@ final class CurrentReadingCell: UICollectionViewCell {
             $0.top.equalTo(dateInfoStack.snp.bottom).offset(4)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(6)
-            $0.bottom.equalToSuperview()
         }
         
         // 저널 버튼
         journalButton.snp.makeConstraints {
-            $0.top.equalTo(progressEditView.snp.bottom).offset(16)
-            $0.trailing.equalToSuperview().inset(16)
+            $0.top.equalTo(progressEditView.snp.bottom).offset(6)
+            $0.trailing.equalToSuperview().inset(8)
             $0.leading.equalTo(titleLabel)
             $0.height.equalTo(32)
             $0.bottom.equalToSuperview().inset(16)


### PR DESCRIPTION
## ☄️Pull Request

이슈번호 #143 

## 💬 작업 내용 + 변경 사항

- 메인화면 현재 읽는 책 UI레이아웃 조정
- 

## 📷 구현
<img width="295" height="640" alt="IMG_1305" src="https://github.com/user-attachments/assets/d004b725-847c-4eb3-a1f2-e95447c0cc11" />
<img width="295" height="640" alt="IMG_1309" src="https://github.com/user-attachments/assets/af5afb04-77c4-4f51-9315-1fb4341f5b62" />


## 📎 레퍼런스

## Close Issue

Close #143

# ✔️Checklist

- [ ✅ ] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [ ✅ ] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [ ✅] 필요없는 주석, 프린트문 제거했는지 확인
- [ ✅ ] 컨벤션 지켰는지 확인
- [ ✅ ] final, private 제대로 넣었는지 확인
- [ ✅ ] 다양한 디바이스에 레이아웃이 대응되는지 확인