### PR TITLE
[design] #147 메인배너 카드로 넘기기

### DIFF
--- a/UnknownBookArchive/UnknownBookArchive.xcodeproj/project.pbxproj
+++ b/UnknownBookArchive/UnknownBookArchive.xcodeproj/project.pbxproj
@@ -114,7 +114,7 @@
 				};
 			};
 			buildConfigurationList = 58619E502ECBF85D00333D36 /* Build configuration list for PBXProject "UnknownBookArchive" */;
-			developmentRegion = en;
+			developmentRegion = ko;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -174,7 +174,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = UnknownBookArchive/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "낯선책방";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "$(PRODUCT_NAME)앱이 사용자의 책 표지를 설정하기 위해 사진 앨범에 접근합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "UnknownBookArchive앱이 사용자의 책 표지를 설정하기 위해 사진 앨범에 접근합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -218,7 +218,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = UnknownBookArchive/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "낯선책방";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "$(PRODUCT_NAME)앱이 사용자의 책 표지를 설정하기 위해 사진 앨범에 접근합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "UnknownBookArchive앱이 사용자의 책 표지를 설정하기 위해 사진 앨범에 접근합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -254,6 +254,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -320,6 +321,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";

--- a/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/CurrentReadingCell.swift
+++ b/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/CurrentReadingCell.swift
@@ -10,6 +10,17 @@ final class CurrentReadingCell: UICollectionViewCell {
     let disposeBag = DisposeBag()
     private var book: Book?
     
+    private let cardView: UIView = {
+            let v = UIView()
+            v.backgroundColor = .white
+            v.layer.cornerRadius = 12
+            v.layer.shadowColor = UIColor.black.cgColor
+            v.layer.shadowOpacity = 0.08
+            v.layer.shadowRadius = 6
+            v.layer.shadowOffset = CGSize(width: 0, height: 2)
+            return v
+        }()
+
     
     // MARK: - UI 요소
     let thumbnailImageView = UIImageView()
@@ -39,6 +50,12 @@ final class CurrentReadingCell: UICollectionViewCell {
     // MARK: - Init
     override init(frame: CGRect) {
         super.init(frame: frame)
+        
+        contentView.addSubview(cardView)
+                cardView.snp.makeConstraints {
+                    $0.edges.equalToSuperview().inset(4)
+                }
+        
         setupUI()
         setupLayout()
         
@@ -102,6 +119,12 @@ final class CurrentReadingCell: UICollectionViewCell {
     // MARK: - Layout
     private func setupLayout() {
         
+        cardView.addSubview(thumbnailImageView)
+                cardView.addSubview(titleLabel)
+                cardView.addSubview(authorLabel)
+                cardView.addSubview(progressEditView)
+                cardView.addSubview(journalButton)
+        
         // MARK: 카드 내부 UI 추가
         contentView.addSubview(thumbnailImageView)
         contentView.addSubview(titleLabel)
@@ -121,13 +144,15 @@ final class CurrentReadingCell: UICollectionViewCell {
         
         // 썸네일
         thumbnailImageView.snp.makeConstraints {
-            $0.top.leading.equalToSuperview().inset(8)
+            $0.top.equalToSuperview().inset(18)
+            $0.leading.equalToSuperview().inset(20)
             $0.size.equalTo(CGSize(width: 97, height: 144))
         }
+
         
         // 제목
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(23)
+            $0.top.equalToSuperview().offset(35)
             $0.leading.equalTo(thumbnailImageView.snp.trailing).offset(16)
             $0.trailing.equalToSuperview().inset(8)
         }
@@ -136,13 +161,13 @@ final class CurrentReadingCell: UICollectionViewCell {
         authorLabel.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(4)
             $0.leading.equalTo(titleLabel)
-            $0.trailing.equalToSuperview().inset(8)
+            $0.trailing.equalToSuperview().inset(30) 
             
         }
         progressEditView.snp.makeConstraints {
             $0.top.equalTo(authorLabel.snp.bottom).offset(6)
             $0.leading.equalTo(titleLabel)
-            $0.trailing.equalToSuperview().inset(8)
+            $0.trailing.equalToSuperview().inset(30)
             $0.height.equalTo(40)
         }
         
@@ -164,10 +189,10 @@ final class CurrentReadingCell: UICollectionViewCell {
         // 저널 버튼
         journalButton.snp.makeConstraints {
             $0.top.equalTo(progressEditView.snp.bottom).offset(6)
-            $0.trailing.equalToSuperview().inset(8)
+            $0.trailing.equalToSuperview().inset(30)
             $0.leading.equalTo(titleLabel)
             $0.height.equalTo(32)
-            $0.bottom.equalToSuperview().inset(16)
+            
         }
     }
     

--- a/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/CurrentReadingCell.swift
+++ b/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/CurrentReadingCell.swift
@@ -144,24 +144,24 @@ final class CurrentReadingCell: UICollectionViewCell {
         
         // 썸네일
         thumbnailImageView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(18)
-            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalToSuperview().inset(16)
+            $0.leading.equalToSuperview().inset(16)
             $0.size.equalTo(CGSize(width: 97, height: 144))
         }
 
         
         // 제목
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(35)
+            $0.top.equalToSuperview().offset(23)
             $0.leading.equalTo(thumbnailImageView.snp.trailing).offset(16)
-            $0.trailing.equalToSuperview().inset(8)
+            $0.trailing.equalToSuperview().inset(16)
         }
         
         // 작가
         authorLabel.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(4)
             $0.leading.equalTo(titleLabel)
-            $0.trailing.equalToSuperview().inset(30) 
+            $0.trailing.equalToSuperview().inset(16)
             
         }
         progressEditView.snp.makeConstraints {
@@ -173,25 +173,27 @@ final class CurrentReadingCell: UICollectionViewCell {
         
         
         // 날짜 + 진행률
-        dateInfoStack.snp.makeConstraints {
-            $0.top.equalTo(progressEditView.snp.top).offset(10)
-            $0.leading.trailing.equalToSuperview()
-
+        dateInfoStack.snp.remakeConstraints {
+            $0.top.equalTo(progressEditView.snp.top).offset(16)
+            $0.leading.equalTo(progressBar.snp.leading)
+            $0.trailing.equalTo(progressBar.snp.trailing)
         }
-        
+
         // 진행률 바
         progressBar.snp.makeConstraints {
             $0.top.equalTo(dateInfoStack.snp.bottom).offset(4)
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(6)
+            $0.leading.equalTo(thumbnailImageView.snp.trailing).offset(16)
+            $0.trailing.equalToSuperview().inset(-13)
+            $0.height.equalTo(4)
         }
-        
+
         // 저널 버튼
         journalButton.snp.makeConstraints {
-            $0.top.equalTo(progressEditView.snp.bottom).offset(6)
-            $0.trailing.equalToSuperview().inset(30)
+            $0.top.equalTo(progressEditView.snp.bottom).offset(16)
+            $0.trailing.equalToSuperview().inset(16)
             $0.leading.equalTo(titleLabel)
             $0.height.equalTo(32)
+            $0.bottom.equalToSuperview().inset(23)
             
         }
     }

--- a/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/ReadingHomeViewController.swift
+++ b/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/ReadingHomeViewController.swift
@@ -554,32 +554,34 @@ final class ReadingHomeViewController: UIViewController {
             $0.width.equalTo(scrollView.frameLayoutGuide)
         }
         
+        // 하늘색 카드
         greetingSectionView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(290)
+            $0.height.equalTo(274)
         }
         
+        // 책방지기님~
         greetingLabel.snp.makeConstraints {
             $0.top.equalTo(greetingSectionView).offset(16)
             $0.leading.trailing.equalTo(greetingSectionView).inset(16)
-            $0.height.equalTo(70)
+            $0.height.equalTo(56)
         }
         
+        // 하얀 카드
         currentReadingCardView.snp.makeConstraints {
             $0.top.equalTo(greetingLabel.snp.bottom).offset(10)
             $0.leading.trailing.equalTo(greetingSectionView).inset(16)
-            $0.height.equalTo(180)
+            $0.height.equalTo(176)
             $0.bottom.equalTo(greetingSectionView.snp.bottom).offset(-16)
         }
 
-        
         currentReadingCollectionView.snp.remakeConstraints {
             $0.edges.equalTo(currentReadingCardView)
         }
 
-        
+        // 책추가하기 버튼
         addBookButton.snp.makeConstraints {
-            $0.top.equalTo(greetingSectionView.snp.bottom).offset(24)
+            $0.top.equalTo(greetingSectionView.snp.bottom).offset(16)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(52)
         }
@@ -615,7 +617,7 @@ final class ReadingHomeViewController: UIViewController {
     // MARK: - 현재 읽는 중 컬렉션 레이아웃
     private func makeCurrentReadingLayout() -> UICollectionViewLayout {
 
-        let cardHeight: CGFloat = 180
+        let cardHeight: CGFloat = 176
 
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(0.97),

--- a/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/ReadingHomeViewController.swift
+++ b/UnknownBookArchive/UnknownBookArchive/ReadingHome/View/ReadingHomeViewController.swift
@@ -182,7 +182,7 @@ final class ReadingHomeViewController: UIViewController {
         finishedBooks = Array(model.finishedBooks.prefix(10))
         
         // 책 개수가 10권을 초과할 때만 더보기 버튼 보이기
-        greetingMoreButton.isHidden = model.currentReadingBooks.count <= 10
+        greetingMoreButton.isHidden = model.currentReadingBooks.count <= 5 // 5권으로 낮춤
         plannedMoreButton.isHidden = model.plannedBooks.count <= 10
         pausedMoreButton.isHidden = model.pausedBooks.count <= 10
         finishedMoreButton.isHidden = model.finishedBooks.count <= 10
@@ -212,13 +212,18 @@ final class ReadingHomeViewController: UIViewController {
     // MARK: - 현재 읽는 중 카드 UI
     private func updateCurrentReadingCardUI() {
         if currentReadingBooks.isEmpty {
+    
+            currentReadingCardView.isHidden = false
             currentReadingEmptyStack.isHidden = false
             currentReadingCollectionView.isHidden = true
         } else {
+            
+            currentReadingCardView.isHidden = true
             currentReadingEmptyStack.isHidden = true
             currentReadingCollectionView.isHidden = false
         }
     }
+
     
     
     // MARK: - show/hide emptyCard or collectionView
@@ -435,6 +440,9 @@ final class ReadingHomeViewController: UIViewController {
         greetingSectionView.addSubview(currentReadingCardView)
         greetingSectionView.addSubview(greetingMoreButton)
         
+        greetingSectionView.addSubview(currentReadingCollectionView)
+
+        
         greetingMoreButton.snp.makeConstraints {
             $0.top.equalTo(greetingSectionView).offset(12)
             $0.trailing.equalTo(greetingSectionView).inset(12)
@@ -449,16 +457,16 @@ final class ReadingHomeViewController: UIViewController {
         currentReadingEmptyStack.addArrangedSubview(currentReadingCardSubtitleLabel)
         
         currentReadingCardView.addSubview(currentReadingEmptyStack)
-        currentReadingCardView.addSubview(currentReadingCollectionView)
+//        currentReadingCardView.addSubview(currentReadingCollectionView)
         
         currentReadingEmptyStack.snp.makeConstraints {
             $0.center.equalToSuperview()
         }
         
-        currentReadingCollectionView.snp.makeConstraints {
-            $0.edges.equalToSuperview().inset(12)
-            $0.height.equalTo(180)
-        }
+//        currentReadingCollectionView.snp.makeConstraints {
+//            $0.edges.equalToSuperview().inset(12)
+//            $0.height.equalTo(180)
+//        }
         
         contentStackView.addArrangedSubview(addBookButton)
         
@@ -548,6 +556,7 @@ final class ReadingHomeViewController: UIViewController {
         
         greetingSectionView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(290)
         }
         
         greetingLabel.snp.makeConstraints {
@@ -562,6 +571,12 @@ final class ReadingHomeViewController: UIViewController {
             $0.height.equalTo(180)
             $0.bottom.equalTo(greetingSectionView.snp.bottom).offset(-16)
         }
+
+        
+        currentReadingCollectionView.snp.remakeConstraints {
+            $0.edges.equalTo(currentReadingCardView)
+        }
+
         
         addBookButton.snp.makeConstraints {
             $0.top.equalTo(greetingSectionView.snp.bottom).offset(24)
@@ -599,30 +614,35 @@ final class ReadingHomeViewController: UIViewController {
     
     // MARK: - 현재 읽는 중 컬렉션 레이아웃
     private func makeCurrentReadingLayout() -> UICollectionViewLayout {
+
+        let cardHeight: CGFloat = 180
+
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .fractionalHeight(1.0)
+            widthDimension: .fractionalWidth(0.97),
+            heightDimension: .absolute(cardHeight)
         )
-        
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        
+
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(160)
+            heightDimension: .absolute(cardHeight)
         )
-        
+
         let group = NSCollectionLayoutGroup.horizontal(
             layoutSize: groupSize,
             subitems: [item]
         )
-        
+
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .groupPagingCentered
-        section.interGroupSpacing = 16
-        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
-        
+
+        section.interGroupSpacing = -10
+
+        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+
         return UICollectionViewCompositionalLayout(section: section)
     }
+
 
 }
 


### PR DESCRIPTION
## ☄️Pull Request

이슈번호 #147 

## 💬 작업 내용 + 변경 사항
- 메인배너 부분 카드형식으로 변경했습니다.
- 현재 읽는 중만 5권 초과하면 더보기 뜨게 했습니다.
- 카드에서는 10권 마저 뜨게 했습니다.                                                                                                  

## 📷 구현
![화면 기록 2025-12-12 오전 10 21 50](https://github.com/user-attachments/assets/68aaea6c-d0ba-4589-b088-0c2ec9657704)


## 📎 노션
https://www.notion.so/2aa470d98ef5806db821d7074b63e520

## Close Issue

Close #147 

# ✔️Checklist

- [ ✅ ] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [ ✅ ] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [ ✅] 필요없는 주석, 프린트문 제거했는지 확인
- [ ✅ ] 컨벤션 지켰는지 확인
- [ ✅ ] final, private 제대로 넣었는지 확인
- [ ✅ ] 다양한 디바이스에 레이아웃이 대응되는지 확인